### PR TITLE
Fix disassembler tracing early exits with some LD instructions

### DIFF
--- a/core/src/disassembler.rs
+++ b/core/src/disassembler.rs
@@ -360,18 +360,14 @@ impl Trace {
             return;
         }
 
-        let cursors = &std::cell::RefCell::new(cursors);
-
         let (step, jump) = compute_step(len, cursor, &op, &rom.cartridge);
-        cursors.borrow_mut().extend(step);
+        cursors.extend(step);
 
-        let Some(jump) = jump else {
-            return
-        };
+        let Some(jump) = jump else { return };
 
         if let Some(to) = Address::from_cursor(&jump) {
             self.add_jump(address, to);
-            cursors.borrow_mut().push(jump);
+            cursors.push(jump);
         }
     }
 

--- a/core/src/disassembler.rs
+++ b/core/src/disassembler.rs
@@ -527,7 +527,15 @@ pub fn compute_step(
                         None,
                     )
                 }
-                (None, 0x0000..=0x7FFF) => (None, None),
+                (None, 0x0000..=0x7FFF) => (
+                    Some(Cursor {
+                        bank0,
+                        bank,
+                        pc: pc.wrapping_add(len as u16),
+                        reg_a: None,
+                    }),
+                    None,
+                ),
                 _ => (
                     Some(Cursor {
                         bank0,


### PR DESCRIPTION
This took a long time to track down. I'm not entirely certain what the real solution should be, but this seems to fix it.

These screenshots show the problem. The disassembly prematurely ends at an LD instruction:

<img width="1017" alt="Screenshot 2024-12-23 at 8 51 53 PM" src="https://github.com/user-attachments/assets/3a6cfc1f-637d-40f6-aafe-b23efae38497" />

<img width="1017" alt="Screenshot 2024-12-23 at 8 55 26 PM" src="https://github.com/user-attachments/assets/2923b510-8e46-4820-9aa3-f899d14f0a93" />

I found the problem was that `None` was being returned as the first `Cursor` for this specific instruction pattern.

While tracking this down, I also noticed a bizarre use of `RefCell` that isn't needed. So I removed that in a second commit.