### PR TITLE
Implementing output wave trace of the emulation in VCD format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ log.txt
 test_rom/test.o
 core/test_output
 core/tests/gameboy-test-roms
+core/vcd_trace
 license/license.html
 android/app/release
 gameroy.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,6 +1217,7 @@ dependencies = [
  "rand",
  "rayon",
  "text-diff",
+ "vcd",
 ]
 
 [[package]]
@@ -3609,6 +3610,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcd"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4505774fc84de82eb04caa74d859342b0daa376f4c6df45149593245dd62c004"
 
 [[package]]
 name = "vec_map"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,8 +18,10 @@ harness = false
 
 [features]
 io_trace = []
+wave_trace = ["dep:vcd"]
 
 [dependencies]
+vcd = { version = "0.7.0", optional = true }
 
 [dev-dependencies]
 image = { version = "0.25.4", default-features = false, features = ["png"] }

--- a/core/src/bin/run.rs
+++ b/core/src/bin/run.rs
@@ -1,0 +1,72 @@
+use gameroy::{
+    consts::CLOCK_SPEED,
+    gameboy::{cartridge::Cartridge, GameBoy},
+    interpreter::Interpreter,
+};
+
+fn parse_timeout(timeout: &str) -> Option<u64> {
+    Some(if timeout.ends_with("s") {
+        timeout[..timeout.len() - 1].parse::<u64>().ok()? * CLOCK_SPEED
+    } else if timeout.ends_with("ms") {
+        timeout[..timeout.len() - 2].parse::<u64>().ok()? * CLOCK_SPEED / 1000
+    } else {
+        timeout.parse::<u64>().ok()?
+    })
+}
+
+fn main() {
+    let mut args = std::env::args();
+    let mut boot_rom_path = None;
+    let mut rom_path = None;
+    let mut timeout = CLOCK_SPEED; // 1 second
+
+    // Skip program name
+    let _ = args.next();
+
+    while let Some(arg) = args.next() {
+        if arg == "--boot" {
+            boot_rom_path = Some(args.next().expect("Missing arg value"));
+        } else if arg == "--timeout" {
+            timeout = parse_timeout(&args.next().expect("Missing arg value"))
+                .expect("Invalid timeout value");
+        } else if arg.starts_with("--") {
+            panic!("Unknown argument: {}", arg);
+        } else {
+            rom_path = Some(arg);
+        }
+    }
+
+    println!(
+        "Running ROM: {}",
+        rom_path.as_ref().expect("No rom path provided")
+    );
+    println!("Boot ROM: {}", boot_rom_path.as_deref().unwrap_or("None"));
+
+    let rom = std::fs::read(rom_path.expect("No rom path provided")).unwrap();
+    let boot_rom = boot_rom_path.map(|path| {
+        std::fs::read(&path)
+            .unwrap()
+            .try_into()
+            .expect("Boot ROM must be 256 bytes")
+    });
+
+    let cartridge = Cartridge::new(rom).expect("Invalid ROM");
+
+    println!(
+        "Cartridge: {:} ({})",
+        cartridge.kind_name(),
+        cartridge.header.cartridge_type
+    );
+
+    let mut gameboy = GameBoy::new(boot_rom, cartridge);
+
+    let mut inter = Interpreter(&mut gameboy);
+
+    while inter.0.clock_count < timeout {
+        inter.interpret_op();
+        if inter.0.read(inter.0.cpu.pc) == 0x40 {
+            println!("LD B, B detected, stopping");
+            break;
+        }
+    }
+}

--- a/core/src/bin/run.rs
+++ b/core/src/bin/run.rs
@@ -5,10 +5,10 @@ use gameroy::{
 };
 
 fn parse_timeout(timeout: &str) -> Option<u64> {
-    Some(if timeout.ends_with("s") {
-        timeout[..timeout.len() - 1].parse::<u64>().ok()? * CLOCK_SPEED
-    } else if timeout.ends_with("ms") {
-        timeout[..timeout.len() - 2].parse::<u64>().ok()? * CLOCK_SPEED / 1000
+    Some(if let Some(value) = timeout.strip_suffix("s") {
+        value.parse::<u64>().ok()? * CLOCK_SPEED
+    } else if let Some(value) = timeout.strip_suffix("ms") {
+        value.parse::<u64>().ok()? * CLOCK_SPEED / 1000
     } else {
         timeout.parse::<u64>().ok()?
     })
@@ -68,5 +68,11 @@ fn main() {
             println!("LD B, B detected, stopping");
             break;
         }
+    }
+    #[cfg(feature = "wave_trace")]
+    {
+        inter.0.update_all();
+        println!("VCD committed on end: {}", inter.0.clock_count);
+        inter.0.vcd_writer.commit().unwrap();
     }
 }

--- a/core/src/gameboy/cartridge.rs
+++ b/core/src/gameboy/cartridge.rs
@@ -255,9 +255,16 @@ impl MbcSpecification {
             }
             Ok(size) => size,
             Err(err) => {
-                let size = *ROM_SIZES.iter().find(|&&x| x >= rom.len()).unwrap();
-                writeln!(error, "{}, deducing size from ROM size as {}", err, size,).unwrap();
-                size
+                match ROM_SIZES.iter().copied().find(|&x| x >= rom.len()) {
+                    Some(size) => {
+                        writeln!(error, "{}, deducing size from ROM size as {}", err, size,).unwrap();
+                        size
+                    }
+                    None => {
+                        writeln!(error, "{}", err).unwrap();
+                        return None;
+                    }
+                }
             }
         };
 

--- a/core/src/gameboy/cpu.rs
+++ b/core/src/gameboy/cpu.rs
@@ -99,6 +99,10 @@ pub struct Cpu {
     pub ime: ImeState,
     pub state: CpuState,
     pub halt_bug: bool,
+
+    /// The current opcode being executed. This is only used for debugging in the VCD trace.
+    #[cfg(feature = "wave_trace")]
+    pub op: u8,
 }
 impl fmt::Display for Cpu {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/core/src/gameboy/ppu.rs
+++ b/core/src/gameboy/ppu.rs
@@ -320,11 +320,11 @@ pub struct Ppu {
     pub state: u8,
     /// When making the LY==LYC comparison, uses this value instead of ly to control the comparison
     /// timing. This is 0xFF if this will not update the stat.
-    ly_for_compare: u8,
+    pub ly_for_compare: u8,
 
     /// A rising edge on this signal causes a STAT interrupt.
-    stat_signal: bool,
-    ly_compare_signal: bool,
+    pub stat_signal: bool,
+    pub ly_compare_signal: bool,
     /// use this value instead of the current stat mode when controlling the stat interrupt signal,
     /// to control the timing. 0xff means that this will not trigger a interrupt.
     ///
@@ -332,7 +332,7 @@ pub struct Ppu {
     /// Mode 1 - Vertical Blank
     /// Mode 2 - OAM Search
     /// Mode 3 - Drawing pixels
-    stat_mode_for_interrupt: u8,
+    pub stat_mode_for_interrupt: u8,
 
     /// Which clock cycle the PPU where last updated
     pub last_clock_count: u64,
@@ -374,7 +374,7 @@ pub struct Ppu {
     /// The x position in the current scanline, from -(8 + scx%8) to 160. Negative values
     /// (represented by positives between 241 and 255) are use for detecting sprites that starts
     /// to the left of the screen, and for discarding pixels for scrolling.
-    scanline_x: u8,
+    pub scanline_x: u8,
 }
 
 fn dbg_fmt_hash<T: std::hash::Hash>(value: &T) -> impl std::fmt::Debug {
@@ -942,6 +942,9 @@ impl Ppu {
         // Writing to wx do some time traveling shenanigans. Make sure they are not observable.
         debug_assert!(ppu.last_clock_count <= gb.clock_count);
 
+        #[cfg(feature = "wave_trace")]
+        gb.vcd_writer.trace_ppu(ppu.last_clock_count, ppu).unwrap();
+
         ppu.last_clock_count = gb.clock_count;
 
         if ppu.lcdc & 0x80 == 0 {
@@ -959,9 +962,15 @@ impl Ppu {
 
         if ppu.next_clock_count >= gb.clock_count {
             Self::update_dma(gb, ppu, gb.clock_count);
+
+            #[cfg(feature = "wave_trace")]
+            gb.vcd_writer.trace_ppu(gb.clock_count, ppu).unwrap();
         }
 
         while ppu.next_clock_count < gb.clock_count {
+            #[cfg(feature = "wave_trace")]
+            let curr_ppu_clock_count = ppu.next_clock_count;
+
             Self::update_dma(gb, ppu, ppu.next_clock_count);
             // println!("state: {}", state);
             match ppu.state {
@@ -1026,7 +1035,10 @@ impl Ppu {
                 6 => {
                     ppu.line_start_clock_count = ppu.next_clock_count;
                     ppu.screen_x = 0;
-                    if gb.clock_count > ppu.next_clock_count + 456 {
+
+                    let use_optimization = !cfg!(feature = "wave_trace");
+
+                    if use_optimization && gb.clock_count > ppu.next_clock_count + 456 {
                         if ppu.wy == ppu.ly {
                             ppu.reach_window = true;
                         }
@@ -1518,6 +1530,9 @@ impl Ppu {
                 }
                 _ => unreachable!(),
             }
+
+            #[cfg(feature = "wave_trace")]
+            gb.vcd_writer.trace_ppu(curr_ppu_clock_count, ppu).unwrap();
         }
 
         Self::update_dma(gb, ppu, gb.clock_count);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -6,3 +6,6 @@ pub mod gameboy;
 pub mod interpreter;
 pub mod parser;
 pub mod save_state;
+
+#[cfg(feature = "wave_trace")]
+mod wave_trace;

--- a/core/src/wave_trace.rs
+++ b/core/src/wave_trace.rs
@@ -1,0 +1,375 @@
+//! Trace the GameBoy state to a VCD wave file for debugging. Its main purpose is to compare the
+//! emulator's state with the state of the [DMG-SIM](https://github.com/msinger/dmg-sim) and
+//! [dmgcpu](https://github.com/emu-russia/dmgcpu) Verilog simulations.
+
+use std::cell::{Cell, RefCell};
+use std::fs::File;
+use std::io::BufWriter;
+
+use crate::gameboy::cpu::Cpu;
+use crate::gameboy::ppu::Ppu;
+use crate::gameboy::timer::Timer;
+use crate::gameboy::GameBoy;
+
+// NOTE: The actual clock period should be 1/(2^22 Hz) = 238.419 ns, but msinger's
+// dmg-sim (the verilog simulation I am comparing to) uses a period of 240 ns.
+const TIMESCALE: u64 = 1; // ns
+const CYCLE_PERIOD: u64 = 240 / TIMESCALE;
+
+// Offset the timestampst to make it align with the other simulations.
+const OFFSET: i64 = (-5625669120) / TIMESCALE as i64;
+
+// Convert clock count to timestamp
+fn clock_to_timestamp(clock: u64) -> u64 {
+    (clock * CYCLE_PERIOD).saturating_add_signed(OFFSET)
+}
+
+type MaxWidth = u16;
+type WireIndex = u8;
+
+macro_rules! decl_regs {
+    ($name:ident, $module:literal, $var:ident : $type:ty, $($reg:ident, $width:expr => $value:expr;)*) => {
+        pub struct $name {
+            $($reg: WireIndex,)*
+        }
+        impl $name {
+            fn new(writer: &mut MyWriter) -> std::io::Result<Self> {
+                writer.add_module($module)?;
+                let this = Self {
+                    $($reg: writer.add_wire($width, stringify!($reg))?,)*
+                };
+                writer.close_module()?;
+                Ok(this)
+            }
+
+            fn trace(&self, clock_count: u64, writer: &mut MyWriter, $var: $type) -> std::io::Result<()> {
+                $(writer.change(clock_count, self.$reg, ($value) as MaxWidth)?;)*
+                Ok(())
+            }
+        }
+    };
+}
+
+decl_regs! {
+    GameboyRegs, "gameboy", gb: &GameBoy,
+    serial_data, 8 => gb.serial.borrow().serial_data;
+    serial_control, 8 => gb.serial.borrow().serial_control;
+    joypad_io, 8 => gb.joypad_io;
+    joypad, 8 => gb.joypad;
+    interrupt_flag, 8 => gb.interrupt_flag.get();
+    dma, 8 => gb.dma;
+    interrupt_enabled, 8 => gb.interrupt_enabled;
+    v_blank_trigger, 1 => gb.v_blank_trigger.get() as u8;
+}
+
+decl_regs! {
+    CpuRegs, "cpu", cpu: &Cpu,
+    f, 8 => cpu.f.0;
+    a, 8 => cpu.a;
+    c, 8 => cpu.c;
+    b, 8 => cpu.b;
+    e, 8 => cpu.e;
+    d, 8 => cpu.d;
+    l, 8 => cpu.l;
+    h, 8 => cpu.h;
+    sp, 16 => cpu.sp;
+    pc, 16 => cpu.pc;
+    ime, 2 => cpu.ime;
+    state, 2 => cpu.state;
+    halt_bug, 1 => cpu.halt_bug;
+    op, 8 => cpu.op;
+}
+
+decl_regs! {
+    PpuRegs, "ppu", ppu: &Ppu,
+    lcdc, 8 => ppu.lcdc;
+    stat, 8 => ppu.stat;
+    scy, 8 => ppu.scy;
+    scx, 8 => ppu.scx;
+    ly, 8 => ppu.ly;
+    lyc, 8 => ppu.lyc;
+    bgp, 8 => ppu.bgp;
+    obp0, 8 => ppu.obp0;
+    obp1, 8 => ppu.obp1;
+    wy, 8 => ppu.wy;
+    wx, 8 => ppu.wx;
+
+    state, 8 => ppu.state;
+    ly_for_compare, 8 => ppu.ly_for_compare;
+    stat_signal, 1 => ppu.stat_signal;
+    ly_compare_signal, 1 => ppu.ly_compare_signal;
+    stat_mode_for_interrupt, 2 => ppu.stat_mode_for_interrupt;
+    scanline_x, 8 => ppu.scanline_x;
+}
+
+decl_regs! {
+    TimerRegs, "timer", timer: &Timer,
+    div, 16 => timer.div;
+    tima, 8 => timer.tima;
+    tma, 8 => timer.tma;
+    tac, 8 => timer.tac;
+    loading, 8 => timer.loading;
+}
+
+struct Wire {
+    id: vcd::IdCode,
+    value: std::cell::Cell<MaxWidth>,
+    width: u8,
+    name: String,
+}
+
+struct MyWriter {
+    writer: vcd::Writer<BufWriter<File>>,
+    // Buffer of (timestamp, wire, value)
+    buffer: Vec<(u64, WireIndex, MaxWidth)>,
+    wires: Vec<Wire>,
+    last_commit: u64,
+}
+impl MyWriter {
+    fn new(filename: &str) -> std::io::Result<Self> {
+        let file = std::fs::File::create(filename).unwrap();
+        let buf = std::io::BufWriter::new(file);
+        let mut writer = vcd::Writer::new(buf);
+
+        writer.timescale(TIMESCALE as u32, vcd::TimescaleUnit::NS)?;
+
+        Ok(Self {
+            writer,
+            buffer: Vec::new(),
+            wires: Vec::new(),
+            last_commit: 0,
+        })
+    }
+
+    fn add_module(&mut self, name: &str) -> std::io::Result<()> {
+        self.writer.add_module(name)
+    }
+
+    fn close_module(&mut self) -> std::io::Result<()> {
+        self.writer.upscope()
+    }
+
+    fn add_wire(&mut self, width: u8, name: &str) -> std::io::Result<WireIndex> {
+        let id = self.writer.add_wire(width as u32, name)?;
+        let index = self.wires.len();
+
+        if index > WireIndex::MAX as usize {
+            panic!("Too many wires");
+        }
+
+        let wire = Wire {
+            id,
+            width,
+            value: 0x8000.into(),
+            name: name.to_string(),
+        };
+
+        self.wires.push(wire);
+
+        Ok(index as WireIndex)
+    }
+
+    fn change(
+        &mut self,
+        clock_count: u64,
+        index: WireIndex,
+        value: MaxWidth,
+    ) -> std::io::Result<()> {
+        let timestamp = clock_to_timestamp(clock_count);
+        self.change_ns(timestamp, index, value)
+    }
+
+    #[inline(never)]
+    fn change_ns(
+        &mut self,
+        timestamp: u64,
+        index: WireIndex,
+        value: MaxWidth,
+    ) -> std::io::Result<()> {
+        let wire = self.wires.get(index as usize).unwrap();
+        debug_assert!(
+            self.last_commit <= timestamp,
+            "{} < {} at {}",
+            self.last_commit,
+            timestamp,
+            wire.name
+        );
+
+        if wire.value.get() == value {
+            return Ok(());
+        }
+        wire.value.set(value);
+
+        if self
+            .buffer
+            .last()
+            .map_or(false, |&(t, i, _)| t == timestamp && i == index)
+        {
+            self.buffer.pop();
+        }
+        self.buffer.push((timestamp, index, value));
+
+        Ok(())
+    }
+
+    fn begin(&mut self) -> std::io::Result<()> {
+        self.writer.enddefinitions()?;
+        self.writer.begin(vcd::SimulationCommand::Dumpvars)?;
+        Ok(())
+    }
+
+    fn commit(&mut self) -> std::io::Result<()> {
+        self.buffer
+            .sort_unstable_by_key(|(timestamp, _, _)| *timestamp);
+
+        for (timestamp, index, value) in self.buffer.drain(..) {
+            if timestamp != self.last_commit {
+                debug_assert!(
+                    self.last_commit <= timestamp,
+                    "{} < {}",
+                    self.last_commit,
+                    timestamp
+                );
+                self.writer.timestamp(timestamp)?;
+                self.last_commit = timestamp;
+            }
+
+            let wire = self.wires.get(index as usize).unwrap();
+            if wire.width == 1 {
+                self.writer.change_scalar(wire.id, value == 1)?;
+            } else {
+                self.writer
+                    .change_vector(wire.id, to_bits(wire.width, value))?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub struct WaveTrace {
+    writer: RefCell<MyWriter>,
+    last_clock_count: Cell<u64>,
+    clk: WireIndex,
+    address_bus: WireIndex,
+    data_bus: WireIndex,
+    read: WireIndex,
+    write: WireIndex,
+    gameboy_regs: GameboyRegs,
+    cpu_regs: CpuRegs,
+    ppu_regs: PpuRegs,
+    timer_regs: TimerRegs,
+}
+impl WaveTrace {
+    pub fn new() -> std::io::Result<Self> {
+        let filename = "wave_trace/trace.vcd";
+
+        // create dir if not exists
+        std::fs::create_dir_all("wave_trace").unwrap();
+
+        let mut writer = MyWriter::new(filename)?;
+
+        writer.add_module("gameroy")?;
+
+        let clk = writer.add_wire(1, "clk")?;
+        let address_bus = writer.add_wire(16, "address_bus")?;
+        let data_bus = writer.add_wire(8, "data_bus")?;
+        let read = writer.add_wire(1, "read")?;
+        let write = writer.add_wire(1, "write")?;
+
+        let gameboy_regs = GameboyRegs::new(&mut writer)?;
+        let cpu_regs = CpuRegs::new(&mut writer)?;
+        let ppu_regs = PpuRegs::new(&mut writer)?;
+        let timer_regs = TimerRegs::new(&mut writer)?;
+
+        writer.close_module()?;
+
+        writer.begin()?;
+
+        let this = Self {
+            writer: RefCell::new(writer),
+            last_clock_count: u64::MAX.into(),
+            clk,
+            address_bus,
+            data_bus,
+            read,
+            write,
+            gameboy_regs,
+            cpu_regs,
+            ppu_regs,
+            timer_regs,
+        };
+
+        Ok(this)
+    }
+
+    pub fn trace_gameboy(&self, clock_count: u64, gameboy: &GameBoy) -> std::io::Result<()> {
+        self.trace_gameboy_ex(clock_count, gameboy, None)
+    }
+
+    pub fn trace_gameboy_ex(
+        &self,
+        clock_count: u64,
+        gameboy: &GameBoy,
+        bus: Option<(u16, u8, bool)>,
+    ) -> std::io::Result<()> {
+        let mut writer = self.writer.borrow_mut();
+
+        if self.last_clock_count.get() != u64::MAX {
+            for c in self.last_clock_count.get()..clock_count {
+                let t = clock_to_timestamp(c);
+                let delta = CYCLE_PERIOD / 2;
+                writer.change_ns(t + delta, self.clk, 0)?;
+                writer.change_ns(t + 2 * delta, self.clk, 1)?;
+            }
+        } else {
+            writer.change(clock_count, self.clk, 1)?;
+        }
+
+        if let Some(bus) = bus {
+            writer.change(clock_count - 4, self.address_bus, bus.0 as MaxWidth)?;
+            writer.change(clock_count - 4, self.data_bus, bus.1 as MaxWidth)?;
+            writer.change(clock_count - 4, self.read, !bus.2 as MaxWidth)?;
+            writer.change(clock_count - 4, self.write, bus.2 as MaxWidth)?;
+        } else {
+            writer.change(clock_count - 4, self.read, 0)?;
+            writer.change(clock_count - 4, self.write, 0)?;
+        }
+
+        self.last_clock_count.set(clock_count);
+
+        self.gameboy_regs.trace(clock_count, &mut writer, gameboy)?;
+        self.cpu_regs
+            .trace(clock_count, &mut writer, &gameboy.cpu)?;
+
+        Ok(())
+    }
+
+    pub fn trace_ppu(&self, clock_count: u64, ppu: &Ppu) -> std::io::Result<()> {
+        let mut writer = self.writer.borrow_mut();
+
+        self.ppu_regs.trace(clock_count, &mut writer, ppu)?;
+
+        Ok(())
+    }
+
+    pub fn trace_timer(&self, clock_count: u64, timer: &Timer) -> std::io::Result<()> {
+        let mut writer = self.writer.borrow_mut();
+
+        self.timer_regs.trace(clock_count, &mut writer, timer)?;
+
+        Ok(())
+    }
+
+    pub fn buffer_size(&self) -> usize {
+        self.writer.borrow().buffer.len() * std::mem::size_of::<(u64, WireIndex, MaxWidth)>()
+    }
+
+    pub fn commit(&self) -> std::io::Result<()> {
+        self.writer.borrow_mut().commit()
+    }
+}
+
+fn to_bits(n: u8, value: MaxWidth) -> impl Iterator<Item = vcd::Value> {
+    (0..n).rev().map(move |i| ((value >> i) & 1 == 1).into())
+}


### PR DESCRIPTION
VCD (value change dump) is a format used by EDA tools (like Verilog simulators) that shows the change of signals over time. This will dump the change of every register and internal state of the emulator over time.

This will create a file in `wave_trace/trace.vcd`, which can be opened on GTKWave or Surfer for example

I have the idea of implementing it while playing with [msinger/dmg-sim](https://github.com/msinger/dmg-sim) simulation of DMG CPU B in Verilog, and later by [emu-russia/dmgcpu](https://github.com/emu-russia/dmgcpu). This will make it easier to compare my emulator with a simulation of the original hardware.

Example usage:

```
cargo run -p gameroy-core --bin run --profile release --features=wave_trace -- core/tests/gameboy-test-roms/blargg/cpu_instrs/individual/02-interrupts.gb --timeout 25446964 && vcd2fst wave_trace/trace.vcd wave_trace/trace.fst
```